### PR TITLE
Changed to integer division to fix float error

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -66,7 +66,7 @@ class Search(object):
     # ____________________________________________________________________________________
     def __iter__(self):
         """Generator for iterating over search results"""
-        total_pages = ((self.num_found / self.params['rows']) + 2)
+        total_pages = ((self.num_found // self.params['rows']) + 2)
         for page in range(1, total_pages):
             self.params['page'] = page
             r = self.http_session.get(self.url, params=self.params)


### PR DESCRIPTION
Fixed this error
`Traceback (most recent call last):
  File ".\archive.py", line 7, in <module>
    for result in search:
  File "C:\Programming\Python\Python34\lib\site-packages\internetarchive\search.py", line 70, in __iter__
    for page in range(1, total_pages):
TypeError: 'float' object cannot be interpreted as an integer`

Edited the way `total_pages` was calculated to use integer division